### PR TITLE
Add RuneLite GE Flipping plugin skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,18 @@
 bounce18/bounce18 is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## GE Flipping Helper Plugin
+
+This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API.
+
+### Build Instructions
+
+Install Java 11 and Gradle. Then run:
+
+```bash
+cd ge-flipping-plugin
+./gradlew build
+```
+
+The resulting JAR can be installed into RuneLite.

--- a/ge-flipping-plugin/build.gradle
+++ b/ge-flipping-plugin/build.gradle
@@ -1,0 +1,36 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenLocal()
+    maven {
+        url = 'https://repo.runelite.net'
+        content {
+            includeGroupByRegex "net\\.runelite.*"
+        }
+    }
+    mavenCentral()
+}
+
+def runeLiteVersion = 'latest.release'
+
+dependencies {
+    compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
+    compileOnly 'org.projectlombok:lombok:1.18.30'
+    annotationProcessor 'org.projectlombok:lombok:1.18.30'
+
+    testImplementation 'junit:junit:4.12'
+    testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion
+    testImplementation group: 'net.runelite', name:'jshell', version: runeLiteVersion
+}
+
+group = 'com.bounce'
+version = '1.0-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(11)
+    }
+}
+

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
@@ -1,0 +1,29 @@
+package com.bounce.geflipping;
+
+import javax.swing.*;
+import java.awt.*;
+
+class GeFlippingPanel extends JPanel
+{
+    private final JLabel coinsLabel = new JLabel();
+    private final JLabel suggestionLabel = new JLabel();
+
+    GeFlippingPanel()
+    {
+        setLayout(new GridLayout(0, 1));
+        add(new JLabel("Coins:"));
+        add(coinsLabel);
+        add(new JLabel("Suggested Item:"));
+        add(suggestionLabel);
+    }
+
+    void setCoins(int coins)
+    {
+        coinsLabel.setText(String.valueOf(coins));
+    }
+
+    void setSuggestion(int itemId, Margin margin)
+    {
+        suggestionLabel.setText(itemId + " profit:" + margin.profit());
+    }
+}

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
@@ -1,0 +1,121 @@
+package com.bounce.geflipping;
+
+import com.google.common.collect.Ordering;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Client;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
+import net.runelite.api.events.GameTick;
+import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.plugins.Plugin;
+import net.runelite.client.plugins.PluginDescriptor;
+import net.runelite.client.ui.ClientToolbar;
+import net.runelite.client.ui.NavigationButton;
+
+import javax.inject.Inject;
+import javax.swing.*;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Slf4j
+@PluginDescriptor(name = "GE Flipping Helper")
+public class GeFlippingPlugin extends Plugin
+{
+    @Inject
+    private Client client;
+
+    @Inject
+    private ClientToolbar clientToolbar;
+
+    private NavigationButton navButton;
+    private GeFlippingPanel panel;
+
+    private static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
+
+    @Override
+    protected void startUp() throws Exception
+    {
+        panel = new GeFlippingPanel();
+        navButton = NavigationButton.builder()
+                .tooltip("GE Flipping Helper")
+                .icon(new ImageIcon(getClass().getResource("/geflipping_icon.png")))
+                .panel(panel)
+                .build();
+        clientToolbar.addNavigation(navButton);
+    }
+
+    @Override
+    protected void shutDown() throws Exception
+    {
+        clientToolbar.removeNavigation(navButton);
+    }
+
+    @Subscribe
+    private void onGameTick(GameTick tick)
+    {
+        ItemContainer inv = client.getItemContainer(net.runelite.api.InventoryID.INVENTORY);
+        if (inv == null)
+        {
+            return;
+        }
+
+        int coins = 0;
+        for (Item item : inv.getItems())
+        {
+            if (item.getId() == net.runelite.api.ItemID.COINS_995)
+            {
+                coins += item.getQuantity();
+            }
+        }
+        panel.setCoins(coins);
+
+        try
+        {
+            Map<Integer, Margin> margins = GePriceFetcher.fetchMargins();
+            List<Map.Entry<Integer, Margin>> sorted = margins.entrySet().stream()
+                    .sorted(Comparator.comparingInt(e -> -e.getValue().profit()))
+                    .collect(Collectors.toList());
+            for (Map.Entry<Integer, Margin> entry : sorted)
+            {
+                if (entry.getValue().high <= coins)
+                {
+                    panel.setSuggestion(entry.getKey(), entry.getValue());
+                    break;
+                }
+            }
+        }
+        catch (IOException ex)
+        {
+            log.debug("Failed to fetch prices", ex);
+        }
+    }
+}
+
+class GePriceFetcher
+{
+    private static final ObjectMapper mapper = new ObjectMapper();
+    static Map<Integer, Margin> fetchMargins() throws IOException
+    {
+        JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.PRICE_URL));
+        JsonNode data = node.get("data");
+        return mapper.convertValue(data, Map.class);
+    }
+}
+
+class Margin
+{
+    public int high;
+    public int low;
+
+    public int profit()
+    {
+        return high - low;
+    }
+}

--- a/ge-flipping-plugin/src/main/resources/geflipping_icon.png
+++ b/ge-flipping-plugin/src/main/resources/geflipping_icon.png
@@ -1,0 +1,1 @@
+placeholder


### PR DESCRIPTION
## Summary
- add a new `ge-flipping-plugin` RuneLite plugin with build script
- implement `GeFlippingPlugin` to show coin count and item suggestion
- implement a simple Swing panel for the plugin UI
- document build instructions in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68441091b0fc83258d1616889dc9018b