### PR TITLE
Improve GE flipping guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Gradle build outputs
+ge-flipping-plugin/.gradle/
+ge-flipping-plugin/build/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can click the Preview link to take a look at your changes.
 
 ## GE Flipping Helper Plugin
 
-This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API.
+This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API. It now also factors in recent trade volumes to rank items by the highest potential total profit you can achieve with your available coins.
 
 ### Build Instructions
 

--- a/ge-flipping-plugin/build.gradle
+++ b/ge-flipping-plugin/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
@@ -1,12 +1,19 @@
 package com.bounce.geflipping;
 
+import net.runelite.client.ui.PluginPanel;
 import javax.swing.*;
 import java.awt.*;
 
-class GeFlippingPanel extends JPanel
+class GeFlippingPanel extends PluginPanel
 {
     private final JLabel coinsLabel = new JLabel();
-    private final JLabel suggestionLabel = new JLabel();
+    private final JLabel iconLabel = new JLabel();
+    private final JLabel nameLabel = new JLabel();
+    private final JLabel quantityLabel = new JLabel();
+    private final JLabel buyLabel = new JLabel();
+    private final JLabel sellLabel = new JLabel();
+    private final JLabel profitLabel = new JLabel();
+    private final JLabel totalProfitLabel = new JLabel();
 
     GeFlippingPanel()
     {
@@ -14,7 +21,18 @@ class GeFlippingPanel extends JPanel
         add(new JLabel("Coins:"));
         add(coinsLabel);
         add(new JLabel("Suggested Item:"));
-        add(suggestionLabel);
+        add(iconLabel);
+        add(nameLabel);
+        add(new JLabel("Quantity you can buy:"));
+        add(quantityLabel);
+        add(new JLabel("Buy price:"));
+        add(buyLabel);
+        add(new JLabel("Sell price:"));
+        add(sellLabel);
+        add(new JLabel("Profit per item:"));
+        add(profitLabel);
+        add(new JLabel("Total profit:"));
+        add(totalProfitLabel);
     }
 
     void setCoins(int coins)
@@ -22,8 +40,14 @@ class GeFlippingPanel extends JPanel
         coinsLabel.setText(String.valueOf(coins));
     }
 
-    void setSuggestion(int itemId, Margin margin)
+    void setSuggestion(ImageIcon icon, String name, int quantity, Margin margin, int totalProfit)
     {
-        suggestionLabel.setText(itemId + " profit:" + margin.profit());
+        iconLabel.setIcon(icon);
+        nameLabel.setText(name);
+        quantityLabel.setText(String.valueOf(quantity));
+        buyLabel.setText(String.valueOf(margin.low));
+        sellLabel.setText(String.valueOf(margin.high));
+        profitLabel.setText(String.valueOf(margin.profit()));
+        totalProfitLabel.setText(String.valueOf(totalProfit));
     }
 }

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
@@ -1,6 +1,5 @@
 package com.bounce.geflipping;
 
-import com.google.common.collect.Ordering;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
@@ -13,7 +12,9 @@ import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 
 import javax.inject.Inject;
-import javax.swing.*;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.ImageUtil;
+import javax.swing.ImageIcon;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Comparator;
@@ -34,10 +35,14 @@ public class GeFlippingPlugin extends Plugin
     @Inject
     private ClientToolbar clientToolbar;
 
+    @Inject
+    private ItemManager itemManager;
+
     private NavigationButton navButton;
     private GeFlippingPanel panel;
 
-    private static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
+    static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
+    static final String VOLUME_URL = "https://prices.runescape.wiki/api/v1/osrs/5m";
 
     @Override
     protected void startUp() throws Exception
@@ -45,7 +50,7 @@ public class GeFlippingPlugin extends Plugin
         panel = new GeFlippingPanel();
         navButton = NavigationButton.builder()
                 .tooltip("GE Flipping Helper")
-                .icon(new ImageIcon(getClass().getResource("/geflipping_icon.png")))
+                .icon(ImageUtil.loadImageResource(getClass(), "/geflipping_icon.png"))
                 .panel(panel)
                 .build();
         clientToolbar.addNavigation(navButton);
@@ -78,17 +83,37 @@ public class GeFlippingPlugin extends Plugin
 
         try
         {
+            final int availableCoins = coins;
             Map<Integer, Margin> margins = GePriceFetcher.fetchMargins();
+            Map<Integer, VolumeData> volumes = GePriceFetcher.fetchVolumes();
+
             List<Map.Entry<Integer, Margin>> sorted = margins.entrySet().stream()
-                    .sorted(Comparator.comparingInt(e -> -e.getValue().profit()))
+                    .filter(e -> e.getValue().low > 0 && e.getValue().low <= availableCoins)
+                    .sorted(Comparator.comparingInt(e -> {
+                        int id = e.getKey();
+                        Margin m = e.getValue();
+                        VolumeData v = volumes.get(id);
+                        int volLimit = v != null ? v.lowPriceVolume : Integer.MAX_VALUE;
+                        int qty = Math.min(availableCoins / m.low, volLimit);
+                        return -(qty * m.profit());
+                    }))
                     .collect(Collectors.toList());
+
             for (Map.Entry<Integer, Margin> entry : sorted)
             {
-                if (entry.getValue().high <= coins)
-                {
-                    panel.setSuggestion(entry.getKey(), entry.getValue());
-                    break;
-                }
+                int id = entry.getKey();
+                Margin margin = entry.getValue();
+                VolumeData volume = volumes.get(id);
+                int volLimit = volume != null ? volume.lowPriceVolume : Integer.MAX_VALUE;
+                int quantity = Math.min(availableCoins / margin.low, volLimit);
+                int totalProfit = quantity * margin.profit();
+                panel.setSuggestion(
+                    new ImageIcon(itemManager.getImage(id)),
+                    itemManager.getItemComposition(id).getName(),
+                    quantity,
+                    margin,
+                    totalProfit);
+                break;
             }
         }
         catch (IOException ex)
@@ -105,7 +130,16 @@ class GePriceFetcher
     {
         JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.PRICE_URL));
         JsonNode data = node.get("data");
-        return mapper.convertValue(data, Map.class);
+        return mapper.convertValue(data,
+            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, Margin>>() {});
+    }
+
+    static Map<Integer, VolumeData> fetchVolumes() throws IOException
+    {
+        JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.VOLUME_URL));
+        JsonNode data = node.get("data");
+        return mapper.convertValue(data,
+            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, VolumeData>>() {});
     }
 }
 
@@ -118,4 +152,12 @@ class Margin
     {
         return high - low;
     }
+}
+
+class VolumeData
+{
+    public int avgHighPrice;
+    public int highPriceVolume;
+    public int avgLowPrice;
+    public int lowPriceVolume;
 }


### PR DESCRIPTION
## Summary
- calculate best flip based on available coins and item trade volume
- show profit per item and total profit in the panel
- parse wiki prices with proper types

## Testing
- `gradle -p ge-flipping-plugin build`


------
https://chatgpt.com/codex/tasks/task_e_68442c75927c8325bd8b2be69931cee2