### PR TITLE
Improve GE flipping guidance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Gradle build outputs
+ge-flipping-plugin/.gradle/
+ge-flipping-plugin/build/

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ You can click the Preview link to take a look at your changes.
 
 ## GE Flipping Helper Plugin
 
-This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API. It now also factors in recent trade volumes to rank items by the highest potential total profit you can achieve with your available coins.
+This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API. It now also factors in recent trade volumes and ranks the top items you can afford by their total potential profit.
+
+The UI shows a table with icons, quantities to buy, prices to use, and the profit for each suggestion.
 
 ### Build Instructions
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can click the Preview link to take a look at your changes.
 
 ## GE Flipping Helper Plugin
 
-This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API.
+This repository now includes a RuneLite plugin located in `ge-flipping-plugin/`. The plugin displays your coin stack and suggests Grand Exchange items to flip using price data from the OSRS Wiki API. It now also factors in recent trade volumes to rank items by the highest potential total profit you can achieve with your available coins.
 
 ### Build Instructions
 

--- a/ge-flipping-plugin/build.gradle
+++ b/ge-flipping-plugin/build.gradle
@@ -19,6 +19,7 @@ dependencies {
     compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
     compileOnly 'org.projectlombok:lombok:1.18.30'
     annotationProcessor 'org.projectlombok:lombok:1.18.30'
+    implementation 'com.fasterxml.jackson.core:jackson-databind:2.17.1'
 
     testImplementation 'junit:junit:4.12'
     testImplementation group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
@@ -1,38 +1,42 @@
 package com.bounce.geflipping;
 
+import com.bounce.geflipping.model.ItemSuggestion;
 import net.runelite.client.ui.PluginPanel;
+
 import javax.swing.*;
+import javax.swing.table.DefaultTableModel;
 import java.awt.*;
+import java.util.List;
 
 class GeFlippingPanel extends PluginPanel
 {
     private final JLabel coinsLabel = new JLabel();
-    private final JLabel iconLabel = new JLabel();
-    private final JLabel nameLabel = new JLabel();
-    private final JLabel quantityLabel = new JLabel();
-    private final JLabel buyLabel = new JLabel();
-    private final JLabel sellLabel = new JLabel();
-    private final JLabel profitLabel = new JLabel();
-    private final JLabel totalProfitLabel = new JLabel();
+    private final DefaultTableModel tableModel;
 
     GeFlippingPanel()
     {
-        setLayout(new GridLayout(0, 1));
-        add(new JLabel("Coins:"));
-        add(coinsLabel);
-        add(new JLabel("Suggested Item:"));
-        add(iconLabel);
-        add(nameLabel);
-        add(new JLabel("Quantity you can buy:"));
-        add(quantityLabel);
-        add(new JLabel("Buy price:"));
-        add(buyLabel);
-        add(new JLabel("Sell price:"));
-        add(sellLabel);
-        add(new JLabel("Profit per item:"));
-        add(profitLabel);
-        add(new JLabel("Total profit:"));
-        add(totalProfitLabel);
+        setLayout(new BorderLayout());
+        JPanel top = new JPanel(new FlowLayout(FlowLayout.LEFT));
+        top.add(new JLabel("Coins:"));
+        top.add(coinsLabel);
+        add(top, BorderLayout.NORTH);
+
+        tableModel = new DefaultTableModel(new Object[]{"Item", "Qty", "Buy", "Sell", "Profit", "Total"}, 0)
+        {
+            @Override
+            public Class<?> getColumnClass(int column)
+            {
+                return column == 0 ? Icon.class : Object.class;
+            }
+
+            @Override
+            public boolean isCellEditable(int row, int column)
+            {
+                return false;
+            }
+        };
+        JTable table = new JTable(tableModel);
+        add(new JScrollPane(table), BorderLayout.CENTER);
     }
 
     void setCoins(int coins)
@@ -40,14 +44,19 @@ class GeFlippingPanel extends PluginPanel
         coinsLabel.setText(String.valueOf(coins));
     }
 
-    void setSuggestion(ImageIcon icon, String name, int quantity, Margin margin, int totalProfit)
+    void setSuggestions(List<ItemSuggestion> suggestions)
     {
-        iconLabel.setIcon(icon);
-        nameLabel.setText(name);
-        quantityLabel.setText(String.valueOf(quantity));
-        buyLabel.setText(String.valueOf(margin.low));
-        sellLabel.setText(String.valueOf(margin.high));
-        profitLabel.setText(String.valueOf(margin.profit()));
-        totalProfitLabel.setText(String.valueOf(totalProfit));
+        tableModel.setRowCount(0);
+        for (ItemSuggestion s : suggestions)
+        {
+            tableModel.addRow(new Object[]{
+                s.getIcon(),
+                s.getQuantity(),
+                s.getBuyPrice(),
+                s.getSellPrice(),
+                s.getProfit(),
+                s.getTotalProfit()
+            });
+        }
     }
 }

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPanel.java
@@ -1,12 +1,19 @@
 package com.bounce.geflipping;
 
+import net.runelite.client.ui.PluginPanel;
 import javax.swing.*;
 import java.awt.*;
 
-class GeFlippingPanel extends JPanel
+class GeFlippingPanel extends PluginPanel
 {
     private final JLabel coinsLabel = new JLabel();
-    private final JLabel suggestionLabel = new JLabel();
+    private final JLabel iconLabel = new JLabel();
+    private final JLabel nameLabel = new JLabel();
+    private final JLabel quantityLabel = new JLabel();
+    private final JLabel buyLabel = new JLabel();
+    private final JLabel sellLabel = new JLabel();
+    private final JLabel profitLabel = new JLabel();
+    private final JLabel totalProfitLabel = new JLabel();
 
     GeFlippingPanel()
     {
@@ -14,7 +21,18 @@ class GeFlippingPanel extends JPanel
         add(new JLabel("Coins:"));
         add(coinsLabel);
         add(new JLabel("Suggested Item:"));
-        add(suggestionLabel);
+        add(iconLabel);
+        add(nameLabel);
+        add(new JLabel("Quantity you can buy:"));
+        add(quantityLabel);
+        add(new JLabel("Buy price:"));
+        add(buyLabel);
+        add(new JLabel("Sell price:"));
+        add(sellLabel);
+        add(new JLabel("Profit per item:"));
+        add(profitLabel);
+        add(new JLabel("Total profit:"));
+        add(totalProfitLabel);
     }
 
     void setCoins(int coins)
@@ -22,8 +40,14 @@ class GeFlippingPanel extends JPanel
         coinsLabel.setText(String.valueOf(coins));
     }
 
-    void setSuggestion(int itemId, Margin margin)
+    void setSuggestion(ImageIcon icon, String name, int quantity, Margin margin, int totalProfit)
     {
-        suggestionLabel.setText(itemId + " profit:" + margin.profit());
+        iconLabel.setIcon(icon);
+        nameLabel.setText(name);
+        quantityLabel.setText(String.valueOf(quantity));
+        buyLabel.setText(String.valueOf(margin.low));
+        sellLabel.setText(String.valueOf(margin.high));
+        profitLabel.setText(String.valueOf(margin.profit()));
+        totalProfitLabel.setText(String.valueOf(totalProfit));
     }
 }

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
@@ -1,29 +1,27 @@
 package com.bounce.geflipping;
 
+import com.bounce.geflipping.fetch.GePriceFetcher;
+import com.bounce.geflipping.model.ItemSuggestion;
+import com.bounce.geflipping.model.Margin;
+import com.bounce.geflipping.model.VolumeData;
+import com.bounce.geflipping.service.FlipCalculator;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
 import net.runelite.api.ItemContainer;
 import net.runelite.api.events.GameTick;
 import net.runelite.client.eventbus.Subscribe;
+import net.runelite.client.game.ItemManager;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
+import net.runelite.client.util.ImageUtil;
 
 import javax.inject.Inject;
-import net.runelite.client.game.ItemManager;
-import net.runelite.client.util.ImageUtil;
-import javax.swing.ImageIcon;
 import java.io.IOException;
-import java.net.URL;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
-
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Slf4j
 @PluginDescriptor(name = "GE Flipping Helper")
@@ -40,14 +38,18 @@ public class GeFlippingPlugin extends Plugin
 
     private NavigationButton navButton;
     private GeFlippingPanel panel;
+    private FlipCalculator calculator;
+    private GePriceFetcher fetcher;
 
     static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
     static final String VOLUME_URL = "https://prices.runescape.wiki/api/v1/osrs/5m";
 
     @Override
-    protected void startUp() throws Exception
+    protected void startUp()
     {
         panel = new GeFlippingPanel();
+        calculator = new FlipCalculator(itemManager);
+        fetcher = new GePriceFetcher(PRICE_URL, VOLUME_URL);
         navButton = NavigationButton.builder()
                 .tooltip("GE Flipping Helper")
                 .icon(ImageUtil.loadImageResource(getClass(), "/geflipping_icon.png"))
@@ -57,7 +59,7 @@ public class GeFlippingPlugin extends Plugin
     }
 
     @Override
-    protected void shutDown() throws Exception
+    protected void shutDown()
     {
         clientToolbar.removeNavigation(navButton);
     }
@@ -83,81 +85,14 @@ public class GeFlippingPlugin extends Plugin
 
         try
         {
-            final int availableCoins = coins;
-            Map<Integer, Margin> margins = GePriceFetcher.fetchMargins();
-            Map<Integer, VolumeData> volumes = GePriceFetcher.fetchVolumes();
-
-            List<Map.Entry<Integer, Margin>> sorted = margins.entrySet().stream()
-                    .filter(e -> e.getValue().low > 0 && e.getValue().low <= availableCoins)
-                    .sorted(Comparator.comparingInt(e -> {
-                        int id = e.getKey();
-                        Margin m = e.getValue();
-                        VolumeData v = volumes.get(id);
-                        int volLimit = v != null ? v.lowPriceVolume : Integer.MAX_VALUE;
-                        int qty = Math.min(availableCoins / m.low, volLimit);
-                        return -(qty * m.profit());
-                    }))
-                    .collect(Collectors.toList());
-
-            for (Map.Entry<Integer, Margin> entry : sorted)
-            {
-                int id = entry.getKey();
-                Margin margin = entry.getValue();
-                VolumeData volume = volumes.get(id);
-                int volLimit = volume != null ? volume.lowPriceVolume : Integer.MAX_VALUE;
-                int quantity = Math.min(availableCoins / margin.low, volLimit);
-                int totalProfit = quantity * margin.profit();
-                panel.setSuggestion(
-                    new ImageIcon(itemManager.getImage(id)),
-                    itemManager.getItemComposition(id).getName(),
-                    quantity,
-                    margin,
-                    totalProfit);
-                break;
-            }
+            Map<Integer, Margin> margins = fetcher.fetchMargins();
+            Map<Integer, VolumeData> volumes = fetcher.fetchVolumes();
+            List<ItemSuggestion> suggestions = calculator.calculate(coins, margins, volumes);
+            panel.setSuggestions(suggestions);
         }
         catch (IOException ex)
         {
             log.debug("Failed to fetch prices", ex);
         }
     }
-}
-
-class GePriceFetcher
-{
-    private static final ObjectMapper mapper = new ObjectMapper();
-    static Map<Integer, Margin> fetchMargins() throws IOException
-    {
-        JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.PRICE_URL));
-        JsonNode data = node.get("data");
-        return mapper.convertValue(data,
-            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, Margin>>() {});
-    }
-
-    static Map<Integer, VolumeData> fetchVolumes() throws IOException
-    {
-        JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.VOLUME_URL));
-        JsonNode data = node.get("data");
-        return mapper.convertValue(data,
-            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, VolumeData>>() {});
-    }
-}
-
-class Margin
-{
-    public int high;
-    public int low;
-
-    public int profit()
-    {
-        return high - low;
-    }
-}
-
-class VolumeData
-{
-    public int avgHighPrice;
-    public int highPriceVolume;
-    public int avgLowPrice;
-    public int lowPriceVolume;
 }

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/GeFlippingPlugin.java
@@ -1,6 +1,5 @@
 package com.bounce.geflipping;
 
-import com.google.common.collect.Ordering;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.Client;
 import net.runelite.api.Item;
@@ -13,7 +12,9 @@ import net.runelite.client.ui.ClientToolbar;
 import net.runelite.client.ui.NavigationButton;
 
 import javax.inject.Inject;
-import javax.swing.*;
+import net.runelite.client.game.ItemManager;
+import net.runelite.client.util.ImageUtil;
+import javax.swing.ImageIcon;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Comparator;
@@ -34,10 +35,14 @@ public class GeFlippingPlugin extends Plugin
     @Inject
     private ClientToolbar clientToolbar;
 
+    @Inject
+    private ItemManager itemManager;
+
     private NavigationButton navButton;
     private GeFlippingPanel panel;
 
-    private static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
+    static final String PRICE_URL = "https://prices.runescape.wiki/api/v1/osrs/latest";
+    static final String VOLUME_URL = "https://prices.runescape.wiki/api/v1/osrs/5m";
 
     @Override
     protected void startUp() throws Exception
@@ -45,7 +50,7 @@ public class GeFlippingPlugin extends Plugin
         panel = new GeFlippingPanel();
         navButton = NavigationButton.builder()
                 .tooltip("GE Flipping Helper")
-                .icon(new ImageIcon(getClass().getResource("/geflipping_icon.png")))
+                .icon(ImageUtil.loadImageResource(getClass(), "/geflipping_icon.png"))
                 .panel(panel)
                 .build();
         clientToolbar.addNavigation(navButton);
@@ -78,17 +83,37 @@ public class GeFlippingPlugin extends Plugin
 
         try
         {
+            final int availableCoins = coins;
             Map<Integer, Margin> margins = GePriceFetcher.fetchMargins();
+            Map<Integer, VolumeData> volumes = GePriceFetcher.fetchVolumes();
+
             List<Map.Entry<Integer, Margin>> sorted = margins.entrySet().stream()
-                    .sorted(Comparator.comparingInt(e -> -e.getValue().profit()))
+                    .filter(e -> e.getValue().low > 0 && e.getValue().low <= availableCoins)
+                    .sorted(Comparator.comparingInt(e -> {
+                        int id = e.getKey();
+                        Margin m = e.getValue();
+                        VolumeData v = volumes.get(id);
+                        int volLimit = v != null ? v.lowPriceVolume : Integer.MAX_VALUE;
+                        int qty = Math.min(availableCoins / m.low, volLimit);
+                        return -(qty * m.profit());
+                    }))
                     .collect(Collectors.toList());
+
             for (Map.Entry<Integer, Margin> entry : sorted)
             {
-                if (entry.getValue().high <= coins)
-                {
-                    panel.setSuggestion(entry.getKey(), entry.getValue());
-                    break;
-                }
+                int id = entry.getKey();
+                Margin margin = entry.getValue();
+                VolumeData volume = volumes.get(id);
+                int volLimit = volume != null ? volume.lowPriceVolume : Integer.MAX_VALUE;
+                int quantity = Math.min(availableCoins / margin.low, volLimit);
+                int totalProfit = quantity * margin.profit();
+                panel.setSuggestion(
+                    new ImageIcon(itemManager.getImage(id)),
+                    itemManager.getItemComposition(id).getName(),
+                    quantity,
+                    margin,
+                    totalProfit);
+                break;
             }
         }
         catch (IOException ex)
@@ -105,7 +130,16 @@ class GePriceFetcher
     {
         JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.PRICE_URL));
         JsonNode data = node.get("data");
-        return mapper.convertValue(data, Map.class);
+        return mapper.convertValue(data,
+            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, Margin>>() {});
+    }
+
+    static Map<Integer, VolumeData> fetchVolumes() throws IOException
+    {
+        JsonNode node = mapper.readTree(new URL(GeFlippingPlugin.VOLUME_URL));
+        JsonNode data = node.get("data");
+        return mapper.convertValue(data,
+            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, VolumeData>>() {});
     }
 }
 
@@ -118,4 +152,12 @@ class Margin
     {
         return high - low;
     }
+}
+
+class VolumeData
+{
+    public int avgHighPrice;
+    public int highPriceVolume;
+    public int avgLowPrice;
+    public int lowPriceVolume;
 }

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/fetch/GePriceFetcher.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/fetch/GePriceFetcher.java
@@ -1,0 +1,39 @@
+package com.bounce.geflipping.fetch;
+
+import com.bounce.geflipping.model.Margin;
+import com.bounce.geflipping.model.VolumeData;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.net.URL;
+import java.util.Map;
+
+public class GePriceFetcher
+{
+    private static final ObjectMapper mapper = new ObjectMapper();
+
+    private final String priceUrl;
+    private final String volumeUrl;
+
+    public GePriceFetcher(String priceUrl, String volumeUrl)
+    {
+        this.priceUrl = priceUrl;
+        this.volumeUrl = volumeUrl;
+    }
+
+    public Map<Integer, Margin> fetchMargins() throws IOException
+    {
+        JsonNode node = mapper.readTree(new URL(priceUrl));
+        JsonNode data = node.get("data");
+        return mapper.convertValue(data,
+            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, Margin>>() {});
+    }
+
+    public Map<Integer, VolumeData> fetchVolumes() throws IOException
+    {
+        JsonNode node = mapper.readTree(new URL(volumeUrl));
+        JsonNode data = node.get("data");
+        return mapper.convertValue(data,
+            new com.fasterxml.jackson.core.type.TypeReference<Map<Integer, VolumeData>>() {});
+    }
+}

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/model/ItemSuggestion.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/model/ItemSuggestion.java
@@ -1,0 +1,68 @@
+package com.bounce.geflipping.model;
+
+import javax.swing.ImageIcon;
+
+public class ItemSuggestion
+{
+    private final int itemId;
+    private final String name;
+    private final ImageIcon icon;
+    private final int quantity;
+    private final int buyPrice;
+    private final int sellPrice;
+    private final int profit;
+    private final int totalProfit;
+
+    public ItemSuggestion(int itemId, String name, ImageIcon icon, int quantity,
+                          int buyPrice, int sellPrice, int profit, int totalProfit)
+    {
+        this.itemId = itemId;
+        this.name = name;
+        this.icon = icon;
+        this.quantity = quantity;
+        this.buyPrice = buyPrice;
+        this.sellPrice = sellPrice;
+        this.profit = profit;
+        this.totalProfit = totalProfit;
+    }
+
+    public int getItemId()
+    {
+        return itemId;
+    }
+
+    public String getName()
+    {
+        return name;
+    }
+
+    public ImageIcon getIcon()
+    {
+        return icon;
+    }
+
+    public int getQuantity()
+    {
+        return quantity;
+    }
+
+    public int getBuyPrice()
+    {
+        return buyPrice;
+    }
+
+    public int getSellPrice()
+    {
+        return sellPrice;
+    }
+
+    public int getProfit()
+    {
+        return profit;
+    }
+
+    public int getTotalProfit()
+    {
+        return totalProfit;
+    }
+}

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/model/Margin.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/model/Margin.java
@@ -1,0 +1,12 @@
+package com.bounce.geflipping.model;
+
+public class Margin
+{
+    public int high;
+    public int low;
+
+    public int profit()
+    {
+        return high - low;
+    }
+}

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/model/VolumeData.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/model/VolumeData.java
@@ -1,0 +1,9 @@
+package com.bounce.geflipping.model;
+
+public class VolumeData
+{
+    public int avgHighPrice;
+    public int highPriceVolume;
+    public int avgLowPrice;
+    public int lowPriceVolume;
+}

--- a/ge-flipping-plugin/src/main/java/com/bounce/geflipping/service/FlipCalculator.java
+++ b/ge-flipping-plugin/src/main/java/com/bounce/geflipping/service/FlipCalculator.java
@@ -1,0 +1,50 @@
+package com.bounce.geflipping.service;
+
+import com.bounce.geflipping.model.ItemSuggestion;
+import com.bounce.geflipping.model.Margin;
+import com.bounce.geflipping.model.VolumeData;
+import net.runelite.client.game.ItemManager;
+
+import javax.swing.ImageIcon;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public class FlipCalculator
+{
+    private final ItemManager itemManager;
+
+    public FlipCalculator(ItemManager itemManager)
+    {
+        this.itemManager = itemManager;
+    }
+
+    public List<ItemSuggestion> calculate(int coins, Map<Integer, Margin> margins,
+                                          Map<Integer, VolumeData> volumes)
+    {
+        return margins.entrySet().stream()
+                .filter(e -> e.getValue().low > 0 && e.getValue().low <= coins)
+                .map(e -> toSuggestion(e.getKey(), e.getValue(), volumes.get(e.getKey()), coins))
+                .sorted(Comparator.comparingInt(ItemSuggestion::getTotalProfit).reversed())
+                .limit(5)
+                .collect(Collectors.toList());
+    }
+
+    private ItemSuggestion toSuggestion(int id, Margin m, VolumeData v, int coins)
+    {
+        int volLimit = v != null ? v.lowPriceVolume : Integer.MAX_VALUE;
+        int quantity = Math.min(coins / m.low, volLimit);
+        int profit = m.profit();
+        int total = quantity * profit;
+        return new ItemSuggestion(
+                id,
+                itemManager.getItemComposition(id).getName(),
+                new ImageIcon(itemManager.getImage(id)),
+                quantity,
+                m.low,
+                m.high,
+                profit,
+                total);
+    }
+}


### PR DESCRIPTION
## Summary
- calculate best flip based on available coins and item trade volume
- show profit per item and total profit in the panel
- parse wiki prices with proper types

## Testing
- `gradle -p ge-flipping-plugin build`


------
https://chatgpt.com/codex/tasks/task_e_68442c75927c8325bd8b2be69931cee2